### PR TITLE
Fix setup issues with environment variables

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -8,16 +8,21 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ### Setup local environment
 
-Create an `.env.local` file in the root of this project with the following keys:
+Create an `.env.local` file in the `app/` directory with the following keys:
 
 ```
-QP_AWS_ACCESS_KEY=
-QP_AWS_SECRET_ACCESS_KEY=
+CL_AWS_ACCESS_KEY=
+CL_AWS_SECRET_ACCESS_KEY=
 CL_STAGE=
 CL_TENANT=
 ```
 
-`CL_STAGE` should always be `dev` when running locally.
+Set the following values on the right-hand side of the equal sign (no quotes):
+
+1. `CL_AWS_ACCESS_KEY` should be your AWS access key.
+2. `CL_AWS_SECRET_ACCESS_KEY` should be your AWS secret access key.
+3. `CL_STAGE` should always be `dev` when running locally.
+4. `CL_TENANT` should be your name (`min`, `sophie`, `zhanping`, or `andrey`).
 
 ### Run development server
 

--- a/app/src/models/enums/EnvironmentVariableKey.ts
+++ b/app/src/models/enums/EnvironmentVariableKey.ts
@@ -1,4 +1,6 @@
 export enum EnvironmentVariableKey {
+    CL_AWS_ACCESS_KEY = 'CL_AWS_ACCESS_KEY',
+    CL_AWS_SECRET_ACCESS_KEY = 'CL_AWS_SECRET_ACCESS_KEY',
     STAGE = 'CL_STAGE',
     TENANT = 'CL_TENANT',
 }

--- a/app/src/utils/api/dynamodb.ts
+++ b/app/src/utils/api/dynamodb.ts
@@ -1,15 +1,24 @@
-import { DynamoDB } from '@aws-sdk/client-dynamodb';
+import { DynamoDB, DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
+import { getAccessKeyId, getSecretAccessKeyId, getStage } from '../environment';
+
+const DEV_STAGE = 'dev';
 
 /** Gets DynamoDB client */
 export function getDynamoDbClient(): DynamoDB {
-    const ddb = new DynamoDB({
+    const ddbConfig: DynamoDBClientConfig = {
         apiVersion: '2012-08-10',
         region: 'us-east-1',
-        // credentials: {
-        //     accessKeyId: process.env['CL_AWS_ACCESS_KEY'] as string,
-        //     secretAccessKey: process.env['CL_AWS_SECRET_ACCESS_KEY'] as string,
-        // },
-    });
+    };
+
+    // Local dev environment uses access keys in env variables
+    if (getStage() === DEV_STAGE) {
+        ddbConfig.credentials = {
+            accessKeyId: getAccessKeyId()!,
+            secretAccessKey: getSecretAccessKeyId()!,
+        };
+    }
+
+    const ddb = new DynamoDB(ddbConfig);
 
     return ddb;
 }

--- a/app/src/utils/environment.ts
+++ b/app/src/utils/environment.ts
@@ -28,3 +28,13 @@ export const getStage = (): string | undefined => {
 export const getTenant = (): string | undefined => {
     return getRequiredEnvVar(EnvironmentVariableKey.TENANT);
 };
+
+/** Get access key ID from environment variables */
+export const getAccessKeyId = () => {
+    return getRequiredEnvVar(EnvironmentVariableKey.CL_AWS_ACCESS_KEY);
+};
+
+/** Get secret access key ID from environment variables */
+export const getSecretAccessKeyId = () => {
+    return getRequiredEnvVar(EnvironmentVariableKey.CL_AWS_SECRET_ACCESS_KEY);
+};


### PR DESCRIPTION
* Update `getDynamoDbClient` to use environment variables for AWS access keys on dev environments
* Update README to describe how to set up `.env.local` file