### PR TITLE
Viewing Page Full Stack

### DIFF
--- a/app/src/components/report/ReportCardView.tsx
+++ b/app/src/components/report/ReportCardView.tsx
@@ -1,0 +1,112 @@
+import { IReport } from '@/models';
+import Card from 'react-bootstrap/Card';
+import Stack from 'react-bootstrap/Stack';
+import { Typography, Grid } from '@mui/material';
+import {
+    StyledReportDetails,
+    Box1,
+    Heading,
+    FooterDetails,
+    IDText,
+    Box2,
+} from '@/styles/StyleCardView';
+
+export type ReportCardProps = {
+    report: IReport;
+};
+
+/** Report Card View */
+export default function ReportCard({ report }: ReportCardProps) {
+    return (
+        <Card>
+            <StyledReportDetails>
+                <Grid container spacing={2}>
+                    <Grid item xs={6}>
+                        <Box1>
+                            <Heading variant="h6">Contact Information</Heading>
+                            <Typography>
+                                <strong>Name:</strong> {report.name}
+                            </Typography>
+                            <Typography>
+                                <strong>Email Address:</strong> {report.emailAddress}
+                            </Typography>
+                            <Typography>
+                                <strong>Phone Number:</strong> {report.phoneNumber}
+                            </Typography>
+                        </Box1>
+                        <Box1>
+                            <Typography>
+                                <strong>Report Category:</strong> {report.reportCategory}
+                            </Typography>
+                        </Box1>
+                        <Box1>
+                            <Heading variant="h6">Issue Location</Heading>
+                            <Typography>
+                                <strong>Address:</strong> {report.address}
+                            </Typography>
+                        </Box1>
+                        <Box1>
+                            <Typography>
+                                <strong>Issue Description:</strong> {report.issueDescription}
+                            </Typography>
+                        </Box1>
+                        <Box1>
+                            <Heading variant="h6">Status Updates</Heading>
+                            <Grid container spacing={2}>
+                                <Grid item xs={6}>
+                                    <Typography>
+                                        <strong>Email:</strong> {report.email ? 'Yes' : 'No'}
+                                    </Typography>
+                                </Grid>
+                                <Grid item xs={6}>
+                                    <Typography>
+                                        <strong>SMS:</strong> {report.sms ? 'Yes' : 'No'}
+                                    </Typography>
+                                </Grid>
+                            </Grid>
+                        </Box1>
+                    </Grid>
+                    <Grid item xs={6}>
+                        <Box1>
+                            <Typography>
+                                <strong>Attachments:</strong>
+                            </Typography>
+                            <img
+                                src="https://dfstudio-d420.kxcdn.com/wordpress/wp-content/uploads/2019/06/digital_camera_photo-1080x675.jpg"
+                                alt="Attachment image"
+                                style={{
+                                    height: '500px',
+                                    width: '580px',
+                                    overflow: 'hidden',
+                                    objectFit: 'cover',
+                                }}
+                            />
+                        </Box1>
+                        <Box1>
+                            <Typography>
+                                <strong>Status of Report:</strong> {report.statusOfReport}
+                            </Typography>
+                            <Typography>
+                                <strong>Date and Time of Submission:</strong>{' '}
+                                {report.dateTimeOfSubmission}
+                            </Typography>
+                        </Box1>
+                    </Grid>
+                </Grid>
+            </StyledReportDetails>
+            <FooterDetails>
+                <Box1>
+                    <Stack direction="horizontal" gap={3}>
+                        <p className="font-monospace me-auto my-auto">
+                            <IDText>ID: </IDText> {report.reportId}
+                        </p>
+                        <div className="vr"></div>
+                        <Box2 variant="secondary" href={`/report/${report.reportId}/edit`}>
+                            Edit
+                        </Box2>
+                    </Stack>
+                </Box1>
+            </FooterDetails>
+        </Card>
+    );
+}

--- a/app/src/components/report/ReportEdit.tsx
+++ b/app/src/components/report/ReportEdit.tsx
@@ -87,7 +87,7 @@ export default function ReportEdit({
                         type="radio"
                         label={category}
                         name="category"
-                        defaultValue={report?.reportCategory}
+                        checked={report?.reportCategory === category}
                         onChange={() => {
                             updateReport({ reportCategory: category });
                         }}

--- a/app/src/components/report/ReportEdit.tsx
+++ b/app/src/components/report/ReportEdit.tsx
@@ -87,7 +87,7 @@ export default function ReportEdit({
                         type="radio"
                         label={category}
                         name="category"
-                        checked={report?.reportCategory === category}
+                        defaultValue={report?.reportCategory}
                         onChange={() => {
                             updateReport({ reportCategory: category });
                         }}

--- a/app/src/pages/report/[id]/index.tsx
+++ b/app/src/pages/report/[id]/index.tsx
@@ -1,0 +1,39 @@
+import ReportCardView from '@/components/report/ReportCardView';
+import Loading from '@/components/Loading';
+import PageHeader from '@/components/PageHeader';
+import { useReport } from '@/hooks';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import Container from 'react-bootstrap/Container';
+import Stack from 'react-bootstrap/Stack';
+import { PageTitle } from '@/styles/StyleCardView';
+
+const BASE_PAGE_TITLE = 'Report Details';
+
+/** View an existing report */
+export default function ReportDetail() {
+    const router = useRouter();
+    const { report, isLoading } = useReport(router.query.id as string);
+
+    const pageTitle = isLoading ? (
+        BASE_PAGE_TITLE
+    ) : (
+        <PageTitle variant="h4">Report Details</PageTitle>
+    );
+    return (
+        <>
+            <Head>
+                <title>{pageTitle}</title>
+            </Head>
+            <main>
+                <Container>
+                    <Stack>
+                        <PageHeader>{pageTitle}</PageHeader>
+                        <Loading isLoading={isLoading}>Loading report details...</Loading>
+                        {!isLoading && <ReportCardView report={report!} />}
+                    </Stack>
+                </Container>
+            </main>
+        </>
+    );
+}

--- a/app/src/styles/StyleCardView.tsx
+++ b/app/src/styles/StyleCardView.tsx
@@ -1,0 +1,82 @@
+import { styled } from '@mui/material/styles';
+import { Box, Typography } from '@mui/material';
+import ButtonLink from '@/components/ButtonLink';
+
+// Color Scheme:
+// #ECF2F8: Light blue
+// #96b6d4: Mild blue
+// #477096: Dark blue
+// #4F4846: Black
+// #FDF8F5: White
+
+// Define custom styles
+const StyledReportDetails = styled(Box)({
+    '& p': {
+        margin: 0,
+        padding: '5px 0',
+        color: '#4F4846',
+    },
+    '& strong': {
+        color: '#4F4846',
+        textAlign: 'center',
+    },
+    borderRadius: '2px',
+    background: '#FDF8F5',
+    boxShadow: '0px 0px 5px rgba(0, 0, 0, 0.3)',
+});
+
+const Box1 = styled(Box)({
+    padding: '15px',
+    marginBottom: '15px',
+    marginTop: '15px',
+    marginLeft: '15px',
+    marginRight: '15px',
+    border: '2px solid #ccc',
+    borderRadius: '30px',
+    background: 'linear-gradient(45deg, #ECF2F8, #FDF8F5)',
+    boxShadow: '0px 0px 5px rgba(0, 0, 0, 0.3)',
+
+    '&:hover': {
+        background: 'linear-gradient(45deg, #FDF8F5, #ECF2F8)',
+    },
+});
+
+const Heading = styled(Typography)({
+    color: '#477096',
+    fontWeight: 'bold',
+    marginBottom: '10px',
+});
+
+const FooterDetails = styled(Box)({
+    borderRadius: '2px',
+    background: '#FDF8F5',
+    boxShadow:
+        '-5px 0 5px -5px rgba(0, 0, 0, 0.3), 5px 0 5px -5px rgba(0, 0, 0, 0.3), 0 5px 5px -5px rgba(0, 0, 0, 0.3)',
+});
+
+const IDText = styled('span')({
+    color: '#477096',
+    fontWeight: 'bold',
+});
+
+const PageTitle = styled(Typography)({
+    color: '#477096',
+    fontWeight: 'bold',
+    textAlign: 'center',
+});
+
+const Box2 = styled(ButtonLink)({
+    borderRadius: '10px',
+    background: 'linear-gradient(45deg, #96b6d4, #FDF8F5)',
+    color: '#4F4846',
+    border: '2px solid #ccc',
+    boxShadow: '0px 0px 5px rgba(0, 0, 0, 0.3)',
+    fontWeight: 'bold',
+    '&:hover': {
+        background: 'linear-gradient(45deg, #FDF8F5, #96b6d4)',
+        color: 'blue',
+        border: '2px solid blue',
+    },
+});
+
+export { StyledReportDetails, Box1, Heading, FooterDetails, IDText, PageTitle, Box2 };


### PR DESCRIPTION
**Viewing Page Full Stack (UI + Frontend + Backend)**

I used MUI to style the Viewing Page.
I created ReportCardView.tsx to get all the data from DynamoDB (not all actually, since "Attachments" is temporarily a string, Zhanping is working on S3 storage) and show them all on the Report Details.

Demo: (Sorry, this is old :<)

![Viewing Report](https://github.com/CodeDayLabs311/cl311/assets/123401167/7fc44b70-d00a-4d6b-bf09-507d56a41842)

In this demo, I showed what would happen after creating a report. We would see 'Viewing Page'.
Although the 'Status Of Report' was initially set up as 'Submitted', I could choose another option (In Progress, Completed, On Hold, Rejected) if I would like to. Later in the GIF demo, what I chose would store in DynamoDB.
When I clicked on the "Create" button, the 'Viewing Page' was showing up with all the data I filled in the create-a-report form.

Thanks :>
