### PR TITLE
Add permission for GSIs for report and guestbook table

### DIFF
--- a/infra-cdk/lib/stacks/IAMStack.ts
+++ b/infra-cdk/lib/stacks/IAMStack.ts
@@ -22,10 +22,17 @@ export class IAMStack extends cdk.Stack {
             statements: [
                 // Allow access to DynamoDB table
                 new iam.PolicyStatement({
-                    actions: ['dynamodb:Scan', 'dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:Query'],
+                    actions: [
+                        'dynamodb:Scan',
+                        'dynamodb:GetItem',
+                        'dynamodb:PutItem',
+                        'dynamodb:Query',
+                    ],
                     resources: [
                         `arn:aws:dynamodb:${ENVIRONMENT.region}:${ENVIRONMENT.account}:table/${props.tableName}`,
+                        `arn:aws:dynamodb:${ENVIRONMENT.region}:${ENVIRONMENT.account}:table/${props.tableName}/index/*`,
                         `arn:aws:dynamodb:${ENVIRONMENT.region}:${ENVIRONMENT.account}:table/${props.reportsTableName}`,
+                        `arn:aws:dynamodb:${ENVIRONMENT.region}:${ENVIRONMENT.account}:table/${props.reportsTableName}/index/*`,
                     ],
                 }),
             ],


### PR DESCRIPTION
The resources now looks like this
![image](https://github.com/CodeDayLabs311/cl311/assets/93412982/5341de35-e2e8-4edd-a2a9-5278c19276ea)

This fix would grant permission to use dynamodb:Query into both tables and their indices.