### PR TITLE
Rename Index

### DIFF
--- a/infra-cdk/lib/stacks/ReportsTableStack.ts
+++ b/infra-cdk/lib/stacks/ReportsTableStack.ts
@@ -29,13 +29,13 @@ export class ReportsTableStack extends cdk.Stack {
 
         /** Filter by status, then within the filtered result, sort by submission date */
         reportsTable.addGlobalSecondaryIndex({
-            indexName: 'StatusIndex',
+            indexName: 'ReportStatusIndex',
             partitionKey: { name: 'StatusOfReport', type: dynamodb.AttributeType.STRING },
             sortKey: { name: 'DateTimeOfSubmission', type: dynamodb.AttributeType.STRING },
             projectionType: dynamodb.ProjectionType.ALL,
         });
         reportsTable.addGlobalSecondaryIndex({
-            indexName: 'CategoryIndex',
+            indexName: 'ReportCategoryIndex',
             partitionKey: { name: 'ReportCategory', type: dynamodb.AttributeType.STRING },
             /** TODO: sortkey can be something esle */
             sortKey: { name: 'DateTimeOfSubmission', type: dynamodb.AttributeType.STRING },


### PR DESCRIPTION
Rename `StatusIndex` to `ReportStatusIndex` to fix this wave-dev error:
`Resource handler returned message: "Cannot update GSI's properties other than Provisioned Throughput and Contributor Insights Specification. You can create a new GSI with a different name." (RequestToken: 8c4d5ed2-e3c4-46fe-3243-284c2e0a236e, HandlerErrorCode: InvalidRequest)`
