### PR TITLE
Delete the exisiting catergory GSI

### DIFF
--- a/infra-cdk/lib/stacks/ReportsTableStack.ts
+++ b/infra-cdk/lib/stacks/ReportsTableStack.ts
@@ -28,12 +28,12 @@ export class ReportsTableStack extends cdk.Stack {
         );
 
         /** Filter by status, then within the filtered result, sort by submission date */
-        reportsTable.addGlobalSecondaryIndex({
-            indexName: 'ReportStatusIndex',
-            partitionKey: { name: 'StatusOfReport', type: dynamodb.AttributeType.STRING },
-            sortKey: { name: 'DateTimeOfSubmission', type: dynamodb.AttributeType.STRING },
-            projectionType: dynamodb.ProjectionType.ALL,
-        });
+        // reportsTable.addGlobalSecondaryIndex({
+        //     indexName: 'ReportStatusIndex',
+        //     partitionKey: { name: 'StatusOfReport', type: dynamodb.AttributeType.STRING },
+        //     sortKey: { name: 'DateTimeOfSubmission', type: dynamodb.AttributeType.STRING },
+        //     projectionType: dynamodb.ProjectionType.ALL,
+        // });
         // reportsTable.addGlobalSecondaryIndex({
         //     indexName: 'ReportCategoryIndex',
         //     partitionKey: { name: 'ReportCategory', type: dynamodb.AttributeType.STRING },


### PR DESCRIPTION
It still gives the same errror: `Resource handler returned message: "Cannot perform more than one GSI creation or deletion in a single update" (RequestToken: 028c0619-e3ef-98da-1b11-e25a39bc3b34, HandlerErrorCode: InvalidRequest)`

My theory is that we already have an exisiting GSI in our tables:
<img width="678" alt="image" src="https://github.com/CodeDayLabs311/cl311/assets/93412982/3c348cab-fbf8-4f64-b65c-89ba5e01569c">

Since I removed the code for the `CategoryIndex` above and add 1 new GSI (`ReportStatusIndex`) at the same time, I made 2 actions (deletion and creation) in a single update. So AWS is not happy with that.